### PR TITLE
Use /authorize endpoint instead of /login

### DIFF
--- a/flask_awscognito/services/cognito_service.py
+++ b/flask_awscognito/services/cognito_service.py
@@ -29,7 +29,7 @@ class CognitoService:
         quoted_redirect_url = quote(self.redirect_url)
         state = get_state(self.user_pool_id, self.user_pool_client_id)
         full_url = (
-            f"{self.domain}/login"
+            f"{self.domain}/authorize"
             f"?response_type=code"
             f"&client_id={self.user_pool_client_id}"
             f"&redirect_uri={quoted_redirect_url}"


### PR DESCRIPTION
Use `/authorize` endpoint instead of `/login` to allow cognito to try to fetch an already-granted token - if the user already has a login token from cognito's hosted UI, they will just get redirected to the `redirect_uri` specified.

https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html

AFAIK the fact that `/authorize` first checks whether the client already has a login token is not described in the documentation but is an observed functionality.