### PR TITLE
Plugin fails to work with latest defaults from AWS

### DIFF
--- a/flask_awscognito/plugin.py
+++ b/flask_awscognito/plugin.py
@@ -77,9 +77,9 @@ class AWSCognitoAuthentication:
 
     def get_access_token(self, request_args):
         code = request_args.get("code")
-        state = request_args.get("state")
+        state = request_args.get("state") # may not be present in the request from Cognito Hosted UI
         expected_state = get_state(self.user_pool_id, self.user_pool_client_id)
-        if state != expected_state:
+        if state and state != expected_state:
             raise FlaskAWSCognitoError("State for CSRF is not correct ")
         access_token = self.cognito_service.exchange_code_for_token(code)
         return access_token


### PR DESCRIPTION
This pull request adds support for no state parameter received from AWS. 
Before the change, the plugin failed to provide an access token. 
After the change, the access token is provided from the plugin as expected. 

Details: 
The "state" parameter is not sent as part of the request received from the Cognito Hosted UI to the AWS_COGNITO_REDIRECT_URL with the current AWS defaults. 
Also, I could find no setting that enabled the "state" query parameter. 
It looks unnecessary. 
