### PR TITLE
add injection of custom state (useful for internal redirects)

### DIFF
--- a/flask_awscognito/services/__init__.py
+++ b/flask_awscognito/services/__init__.py
@@ -7,6 +7,7 @@ def cognito_service_factory(
     user_pool_client_id,
     user_pool_client_secret,
     redirect_url,
+    client_state,
     region,
     domain,
 ):
@@ -15,6 +16,7 @@ def cognito_service_factory(
         user_pool_client_id,
         user_pool_client_secret,
         redirect_url,
+        client_state,
         region,
         domain,
     )

--- a/flask_awscognito/services/cognito_service.py
+++ b/flask_awscognito/services/cognito_service.py
@@ -1,7 +1,7 @@
 from base64 import b64encode
 from urllib.parse import quote
 import requests
-from flask_awscognito.utils import get_state
+from flask_awscognito.utils import get_state, create_state
 from flask_awscognito.exceptions import FlaskAWSCognitoError
 
 
@@ -12,6 +12,7 @@ class CognitoService:
         user_pool_client_id,
         user_pool_client_secret,
         redirect_url,
+        client_state,
         region,
         domain,
     ):
@@ -19,6 +20,7 @@ class CognitoService:
         self.user_pool_client_id = user_pool_client_id
         self.user_pool_client_secret = user_pool_client_secret
         self.redirect_url = redirect_url
+        self.client_state = client_state
         self.region = region
         if domain.startswith("https://"):
             self.domain = domain
@@ -27,7 +29,7 @@ class CognitoService:
 
     def get_sign_in_url(self):
         quoted_redirect_url = quote(self.redirect_url)
-        state = get_state(self.user_pool_id, self.user_pool_client_id)
+        state = create_state(self.user_pool_id, self.user_pool_client_id, quote(str(self.client_state)))
         full_url = (
             f"{self.domain}/login"
             f"?response_type=code"

--- a/flask_awscognito/utils.py
+++ b/flask_awscognito/utils.py
@@ -1,7 +1,6 @@
 from flask_awscognito.constants import HTTP_HEADER
 from hashlib import md5
 
-
 def extract_access_token(request_headers):
     access_token = None
     auth_header = request_headers.get(HTTP_HEADER)
@@ -9,6 +8,15 @@ def extract_access_token(request_headers):
         _, access_token = auth_header.split()
     return access_token
 
+def create_state(user_pool_id, user_pool_client_id, client_state):
+    result = get_state(user_pool_id=user_pool_id, user_pool_client_id=user_pool_client_id)
+    return result + "--%s" % client_state
+
+def state_valid(user_pool_id, user_pool_client_id, state):
+    hsh = get_state(user_pool_id, user_pool_client_id)
+    if state.startswith(hsh):
+        return True
+    return False
 
 def get_state(user_pool_id, user_pool_client_id):
     return md5(f"{user_pool_client_id}:{user_pool_id}".encode("utf-8")).hexdigest()

--- a/tests/test_cognito_service.py
+++ b/tests/test_cognito_service.py
@@ -12,6 +12,7 @@ def test_base_url(
         user_pool_client_id,
         user_pool_client_secret,
         "redirect",
+        "client_state",
         region,
         domain,
     )
@@ -27,6 +28,7 @@ def test_sign_in_url(
         user_pool_client_id,
         user_pool_client_secret,
         "http://redirect/url",
+        "client_state",
         region,
         domain,
     )
@@ -35,7 +37,7 @@ def test_sign_in_url(
         "/login?response_type=code&"
         "client_id=545isk1een1lvilb9en643g3vd&"
         "redirect_uri=http%3A//redirect/url&"
-        "state=dc0de448b88af41d1cd06387ac2d5102"
+        "state=dc0de448b88af41d1cd06387ac2d5102--client_state"
     )
 
 
@@ -53,6 +55,7 @@ def test_exchange_code_for_token(
         user_pool_client_id,
         user_pool_client_secret,
         "http://redirect/url",
+        "client_state",
         region,
         domain,
     )
@@ -73,6 +76,7 @@ def test_get_user_info(
         user_pool_client_id,
         user_pool_client_secret,
         "http://redirect/url",
+        "client_state",
         region,
         domain,
     )


### PR DESCRIPTION
we can use the `state` parameter to internally redirect a user after login (e.g., they land on a site from a bookmark, but need to auth). This change keeps the md5 hash to help prevent CSRF attacks and is otherwise backwards compatible. Relevant unit tests updated to handle change.